### PR TITLE
[Refactor] 회원가입 & 로그인 & 마이페이지 UI 수정 및 코드 리팩토링

### DIFF
--- a/hps/app/login/page.tsx
+++ b/hps/app/login/page.tsx
@@ -39,10 +39,10 @@ export default function LoginPage() {
 
   return (
     <form onSubmit={Login}>
-      <div className='flex flex-col w-full items-center justify-start gap-16 px-8 py-40'>
-        <div className='flex flex-col w-full items-center justify-center gap-8'>
+      <div className='flex flex-col w-full items-center gap-16 px-8 pt-40'>
+        <div className='flex flex-col w-full items-center justify-center gap-6'>
           <Text className=' text-xl font-[300] text-black-font'>로그인</Text>
-          <Text className=' text-center text-black-font font-[500]'>
+          <Text className=' text-center text-xl text-black-font font-[500]'>
             아이디와 비밀번호를
             <br />
             입력해 주세요
@@ -79,7 +79,7 @@ export default function LoginPage() {
           <Button
             type='submit'
             bgColor='bg-hana-button'
-            className='w-full h-14 px-5 text-white rounded-lg font-[500] text-base'
+            className='w-full h-12 px-8 mt-39 text-white rounded-lg font-[500] text-base'
           >
             로그인
           </Button>

--- a/hps/app/mypage/components/BusinessCode.tsx
+++ b/hps/app/mypage/components/BusinessCode.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 import Button from '@/components/atoms/Button';
-import Input from '@/components/atoms/Input';
 import Text from '@/components/atoms/Text';
 import { businessCodeData } from '@/constants/businessCodeData';
 import Image from 'next/image';
 import { useState } from 'react';
 import { updateUserField } from '@/lib/actions/users';
+import SelectBusinessEdit from './SelectBusinessEdit';
 
 type Props = {
   id: number;
@@ -41,10 +41,10 @@ export default function BusinessCode({ id, label, fname, value }: Props) {
   };
 
   return (
-    <div className='w-full flex flex-col gap-1 pl-8 my-1.5 pt-3 pb-4'>
-      <div className='flex flex-row justify-between items-center'>
+    <div className='w-full flex flex-col px-7 py-3'>
+      <div className='flex justify-between items-center'>
         <Text
-          className='text-base text-black-font font-[400] pr-1 shrink-0'
+          className='text-base text-black-font font-[400] shrink-0'
           tag='span'
         >
           {label}
@@ -53,31 +53,20 @@ export default function BusinessCode({ id, label, fname, value }: Props) {
         {isEdit ? (
           <form
             action={handleSubmit}
-            className='flex flex-row justify-end items-center w-full'
+            className='flex justify-end items-center w-full'
           >
             <input type='hidden' name='id' value={id} />
             <input type='hidden' name='field' value={fname} />
 
-            <Input
-              as='select'
-              name='value'
-              defaultValue={currentValue ?? ''}
-              autoFocus
-              className='w-full text-base text-black-font font-[400] border border-gray-300 rounded mr-5 text-right'
-            >
-              <option value='' disabled>
-                선택하세요
-              </option>
-              {businessCodeData.map(({ code, label }) => (
-                <option key={code} value={code}>
-                  {label}
-                </option>
-              ))}
-            </Input>
+            <input type='hidden' name='value' value={currentValue ?? ''} />
+            <SelectBusinessEdit
+              value={currentValue}
+              onChange={(val) => setCurrentValue(val)}
+            />
 
             <Button
               bgColor='bg-hana-button'
-              className='text-white rounded p-0.5 shrink-0 font-[400]'
+              className='text-white rounded px-1 shrink-0 font-[400]'
               type='submit'
             >
               저장
@@ -88,9 +77,9 @@ export default function BusinessCode({ id, label, fname, value }: Props) {
             onClick={() => {
               setIsEdit(true);
             }}
-            className='flex justify-end items-center gap-1 pr-5 cursor-pointer w-full'
+            className='flex justify-end items-center cursor-pointer w-full'
           >
-            <Text className='text-base pr-4 text-black-font font-[400]' tag='p'>
+            <Text className='text-base text-black-font font-[400]' tag='p'>
               {getLabelByCode(currentValue)}
             </Text>
 
@@ -99,6 +88,7 @@ export default function BusinessCode({ id, label, fname, value }: Props) {
               alt='수정'
               width={6}
               height={11}
+              className='ml-3'
             />
           </div>
         )}

--- a/hps/app/mypage/components/ChangePassword.tsx
+++ b/hps/app/mypage/components/ChangePassword.tsx
@@ -2,18 +2,18 @@
 
 import Button from '@/components/atoms/Button';
 import Input from '@/components/atoms/Input';
-import { useSession } from 'next-auth/react';
+import Text from '@/components/atoms/Text';
 import Image from 'next/image';
 import { useState } from 'react';
 import { changePassword } from '@/lib/actions/users';
 
-export default function ChangePassword() {
+type Props = {
+  userId: number;
+};
+
+export default function ChangePassword({ userId }: Props) {
   const [isEdit, setIsEdit] = useState(false);
   const [message, setMessage] = useState('');
-  const { data: session } = useSession();
-
-  const userId = session?.user?.id;
-  if (!userId) return null;
 
   const handleSubmit = async (formData: FormData) => {
     const newPassword = formData.get('newPassword')?.toString() || '';
@@ -42,66 +42,76 @@ export default function ChangePassword() {
   };
 
   return (
-    <div className='w-full max-w-sm mt-3'>
-      {isEdit ? (
-        <form action={handleSubmit} className='flex flex-col gap-2'>
-          <input type='hidden' name='userId' value={userId} />
-          <div className='flex flex-row'>
-            <div className='flex flex-col gap-2 px-3'>
+    <div className='w-full flex flex-col px-7 py-3'>
+      <div className='flex justify-between items-center gap-4'>
+        <Text
+          className='text-base text-black-font font-[400] shrink-0 pt-2'
+          tag='span'
+        >
+          비밀번호
+        </Text>
+
+        {isEdit ? (
+          <form action={handleSubmit} className='flex flex-col gap-2 w-full'>
+            <input type='hidden' name='userId' value={userId} />
+
+            <div className='flex gap-4 w-full h-6.5'>
               <Input
                 name='currentPassword'
-                placeholder='*기존 비밀번호'
+                placeholder='기존 비밀번호'
                 type='password'
-                className='text-base text-black-font font-[400] border border-gray-300 rounded'
+                className='text-base w-full text-black-font font-[400] border border-gray-300 rounded'
                 autoFocus
               />
-              <Input
-                name='newPassword'
-                placeholder='*새 비밀번호 (6자 이상)'
-                type='password'
-                className='text-base text-black-font font-[400] border border-gray-300 rounded'
-              />
-            </div>
-            <div className='flex flex-col gap-2 px-3'>
               <Button
                 type='reset'
-                className='text-base text-white rounded font-[400] px-5 border border-hana-buttom'
-                bgColor='bg-hana-button'
+                className='font-[400] text-white rounded px-1 min-w-[36.9px]'
+                bgColor='bg-gray-login'
                 onClick={() => setIsEdit(false)}
               >
                 취소
               </Button>
+            </div>
+
+            <div className='flex gap-4 w-full h-6.5'>
+              <Input
+                name='newPassword'
+                placeholder='새로운 비밀번호'
+                type='password'
+                className='text-base w-full text-black-font font-[400] border border-gray-300 rounded'
+              />
               <Button
                 type='submit'
-                className='text-base text-white rounded font-[400] px-5 border border-hana-button'
+                className='font-[400] text-white rounded px-1 min-w-[36.9px]'
                 bgColor='bg-hana-button'
               >
                 변경
               </Button>
             </div>
+          </form>
+        ) : (
+          <div
+            className='flex justify-end items-center cursor-pointer w-full'
+            onClick={() => setIsEdit(true)}
+          >
+            <Text className='text-base text-black-font font-[400]' tag='p'>
+              ******
+            </Text>
+            <Image
+              src='/svgs/ic_profile_change.svg'
+              alt='수정'
+              width={6}
+              height={11}
+              className='ml-3'
+            />
           </div>
-        </form>
-      ) : (
-        <div
-          className='flex items-center gap-1 cursor-pointer'
-          onClick={() => setIsEdit(true)}
-        >
-          <span className='text-sm text-black-font font-medium'>
-            비밀번호 변경
-          </span>
-          <Image
-            src='/svgs/ic_profile_change.svg'
-            alt='수정'
-            width={6}
-            height={11}
-          />
-        </div>
-      )}
+        )}
+      </div>
 
       {message && (
-        <div className='text-sm text-center text-hana-green font-medium my-2'>
+        <Text className='text-xs text-center text-hana-green font-[400] mt-2'>
           {message}
-        </div>
+        </Text>
       )}
     </div>
   );

--- a/hps/app/mypage/components/MyPageClient.tsx
+++ b/hps/app/mypage/components/MyPageClient.tsx
@@ -56,7 +56,7 @@ export default function MyPageClient({
         </div>
         <Button
           bgColor='bg-hana-button'
-          className='w-full h-14 px-5 mt-31 text-white rounded-lg font-[500] text-base'
+          className='w-full h-12 px-5 mt-31 text-white rounded-lg font-[500] text-base'
           onClick={() => signOut({ callbackUrl: '/login' })}
         >
           로그아웃

--- a/hps/app/mypage/components/MyPageClient.tsx
+++ b/hps/app/mypage/components/MyPageClient.tsx
@@ -26,7 +26,7 @@ export default function MyPageClient({
   return (
     <HeaderLayout title='마이페이지'>
       <div className='w-full flex flex-col items-center text-black-font pt-10 px-5 py-5'>
-        <div className='w-full flex justify-center mt-10 mb-6'>
+        <div className='w-full flex justify-center mt-10 mb-10'>
           <Image
             src='/svgs/ic_profile.svg'
             alt='Profile'
@@ -36,9 +36,11 @@ export default function MyPageClient({
           />
         </div>
 
-        <div className='w-full flex flex-col mb-5 font-[400]'>
+        <div className='w-full flex flex-col gap-3 font-[400]'>
           <ProfileItem label='이름' fname='name' value={name} id={id} />
           <ProfileItem label='아이디' fname='loginId' value={loginId} id={id} />
+          <ChangePassword userId={1} />
+
           <ProfileItem
             label='생년월일'
             fname='birthDate'
@@ -52,12 +54,9 @@ export default function MyPageClient({
             id={id}
           />
         </div>
-        <div className='pb-5'>
-          <ChangePassword />
-        </div>
         <Button
           bgColor='bg-hana-button'
-          className='w-full h-14 px-5 text-white rounded-lg font-[500] text-base'
+          className='w-full h-14 px-5 mt-31 text-white rounded-lg font-[500] text-base'
           onClick={() => signOut({ callbackUrl: '/login' })}
         >
           로그아웃

--- a/hps/app/mypage/components/ProfileItem.tsx
+++ b/hps/app/mypage/components/ProfileItem.tsx
@@ -69,7 +69,7 @@ export default function ProfileItem({ id, label, fname, value }: Props) {
         {isEdit && !isName ? (
           <form
             action={handleSubmit}
-            className='flex flex-row justify-end items-center w-full'
+            className='flex justify-end items-center w-full'
           >
             <input type='hidden' name='id' value={id} />
             <input type='hidden' name='field' value={fname} />

--- a/hps/app/mypage/components/ProfileItem.tsx
+++ b/hps/app/mypage/components/ProfileItem.tsx
@@ -10,7 +10,7 @@ import { updateUserField } from '@/lib/actions/users';
 type Props = {
   id: number;
   label: string;
-  fname: 'name' | 'loginId' | 'birthDate';
+  fname: 'name' | 'loginId' | 'password' | 'birthDate';
   value: string;
 };
 
@@ -57,10 +57,10 @@ export default function ProfileItem({ id, label, fname, value }: Props) {
   };
 
   return (
-    <div className='w-full flex flex-col gap-1 pl-8 my-1.5 pt-3 pb-4'>
-      <div className='flex flex-row justify-between items-center'>
+    <div className='w-full flex flex-col px-7 py-3'>
+      <div className='flex justify-between items-center'>
         <Text
-          className='text-base text-black-font font-[400] pr-1 shrink-0'
+          className='text-base text-black-font font-[400] shrink-0'
           tag='span'
         >
           {label}
@@ -79,19 +79,19 @@ export default function ProfileItem({ id, label, fname, value }: Props) {
                 name='value'
                 defaultValue={currentValue}
                 autoFocus
-                className='w-full text-base text-black-font font-[400] border border-gray-300 rounded mr-5 text-right'
+                className='w-full text-base text-black-font font-[400] border border-gray-300 rounded mx-4 text-right'
               />
             ) : (
               <Input
                 name='value'
                 defaultValue={currentValue}
                 autoFocus
-                className='w-full text-base text-black-font font-[400] border border-gray-300 rounded mr-5 text-right'
+                className='w-full text-base text-black-font font-[400] border border-gray-300 rounded mx-4 text-right'
               />
             )}
             <Button
               bgColor='bg-hana-button'
-              className='text-white rounded p-0.5 shrink-0 font-[400]'
+              className='text-white rounded px-1 shrink-0 font-[400]'
               type='submit'
             >
               저장
@@ -102,9 +102,9 @@ export default function ProfileItem({ id, label, fname, value }: Props) {
             onClick={() => {
               if (!isName) setIsEdit(true);
             }}
-            className='flex justify-end items-center gap-1 pr-5 cursor-pointer w-full'
+            className='flex justify-end items-center cursor-pointer w-full'
           >
-            <Text className='text-base pr-4 text-black-font font-[400]' tag='p'>
+            <Text className='text-base text-black-font font-[400]' tag='p'>
               {isBirthDate
                 ? formatBirthDate(currentValue)
                 : currentValue || '-'}
@@ -115,6 +115,7 @@ export default function ProfileItem({ id, label, fname, value }: Props) {
                 alt='수정'
                 width={6}
                 height={11}
+                className='ml-3'
               />
             )}
           </div>

--- a/hps/app/mypage/components/SelectBusinessEdit.tsx
+++ b/hps/app/mypage/components/SelectBusinessEdit.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { businessCodeData } from '@/constants/businessCodeData';
+
+type Props = {
+  value: string | null;
+  onChange: (code: string) => void;
+};
+
+export default function SelectBusinessEdit({ value, onChange }: Props) {
+  return (
+    <Select value={value ?? ''} onValueChange={onChange}>
+      <SelectTrigger className='w-full !h-6.5 border border-gray-300 rounded mx-4 text-base'>
+        <SelectValue placeholder='업종을 선택하세요' />
+      </SelectTrigger>
+      <SelectContent className='max-h-52'>
+        {businessCodeData.map(({ code, label }) => (
+          <SelectItem key={code} value={code} className='text-sm h-10'>
+            {label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/hps/app/signup/components/SelectBusiness.tsx
+++ b/hps/app/signup/components/SelectBusiness.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { businessCodeData } from '@/constants/businessCodeData';
+
+type Props = {
+  value: string;
+  onChange: (code: string) => void;
+  error?: string;
+};
+
+export default function SelectBusiness({ value, onChange, error }: Props) {
+  return (
+    <div className='flex flex-col gap-1 w-full'>
+      <Select value={value} onValueChange={onChange}>
+        <SelectTrigger className='w-full !h-14 border border-[#dddce1] px-6 rounded-lg text-base text-black font-[400]'>
+          <SelectValue placeholder='업종을 선택하세요' />
+        </SelectTrigger>
+        <SelectContent className='max-h-52'>
+          {businessCodeData.map(({ code, label }) => (
+            <SelectItem key={code} value={code}>
+              {label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      {error && (
+        <p className='text-xs text-red-500 font-[300] pl-1 pt-1'>{error}</p>
+      )}
+    </div>
+  );
+}

--- a/hps/app/signup/page.tsx
+++ b/hps/app/signup/page.tsx
@@ -6,8 +6,11 @@ import Text from '@/components/atoms/Text';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { handleSignUp } from '@/lib/actions/signup';
+import SelectBusiness from './components/SelectBusiness';
 
 export default function SignUpPage() {
+  const [selectedBusinessCode, setSelectedBusinessCode] = useState('');
+
   const [errors, setErrors] = useState<Record<string, string>>({});
   const router = useRouter();
   async function SignUp(event: React.FormEvent<HTMLFormElement>) {
@@ -19,9 +22,15 @@ export default function SignUpPage() {
       id: formData.get('id')?.toString() ?? '',
       birth: formData.get('birth')?.toString() ?? '',
       password: formData.get('password')?.toString() ?? '',
+      businessCode: selectedBusinessCode,
     };
 
     const result = await handleSignUp(raw);
+
+    if (!selectedBusinessCode) {
+      setErrors({ businessCode: '업종을 선택해주세요.' });
+      return;
+    }
 
     if (!result.success) {
       if (!result.field) {
@@ -37,11 +46,9 @@ export default function SignUpPage() {
     <form onSubmit={SignUp}>
       <div className='flex flex-col w-full items-center justify-start gap-10 px-8 py-20'>
         <div className='flex flex-col w-full items-center justify-center gap-8'>
-          <Text className=' text-xl font-[300] text-black-font'>회원가입</Text>
-          <Text className=' text-center text-black-font font-[500]'>
-            아이디와 비밀번호를
-            <br />
-            입력해 주세요
+          <Text className='text-xl font-[300] text-black-font'>회원가입</Text>
+          <Text className='text-center text-black-font font-[500]'>
+            정보를 입력해 주세요
           </Text>
         </div>
         <div className='flex flex-col gap-4 w-full'>
@@ -90,8 +97,15 @@ export default function SignUpPage() {
               {errors.birth}
             </Text>
           )}
+
+          <SelectBusiness
+            value={selectedBusinessCode}
+            onChange={setSelectedBusinessCode}
+            error={errors.businessCode}
+          />
         </div>
-        <div className='flex flex-col items-center justify-center gap-4 w-full'>
+
+        <div className='flex flex-col items-center justify-center gap-4 w-full mt-24'>
           <Button
             type='submit'
             bgColor='bg-hana-button'

--- a/hps/app/signup/page.tsx
+++ b/hps/app/signup/page.tsx
@@ -105,11 +105,11 @@ export default function SignUpPage() {
           />
         </div>
 
-        <div className='flex flex-col items-center justify-center gap-4 w-full mt-24'>
+        <div className='flex flex-col items-center justify-center gap-4 mt-24 w-full'>
           <Button
             type='submit'
             bgColor='bg-hana-button'
-            className='w-full h-14 px-5 text-white rounded-lg font-[500] text-base'
+            className='w-full h-12 px-5 text-white rounded-lg font-[500] text-base'
           >
             회원가입
           </Button>

--- a/hps/components/atoms/Input.tsx
+++ b/hps/components/atoms/Input.tsx
@@ -9,7 +9,6 @@ type Props = {
   type?: 'text' | 'password' | 'date';
   defaultValue?: string;
   autoFocus?: boolean;
-  as?: 'input' | 'select';
   children?: ReactNode;
 };
 
@@ -20,30 +19,18 @@ export default function Input({
   className,
   defaultValue,
   autoFocus = false,
-  as = 'input',
   children,
 }: PropsWithChildren<Props>) {
   return (
     <div className={className}>
-      {as === 'select' ? (
-        <select
-          name={name}
-          defaultValue={defaultValue}
-          autoFocus={autoFocus}
-          className='w-full h-full px-2 text-black-font focus:outline-none'
-        >
-          {children}
-        </select>
-      ) : (
-        <input
-          name={name}
-          placeholder={placeholder}
-          className='w-full h-full px-2 text-black-font focus:outline-none'
-          type={type}
-          defaultValue={defaultValue}
-          autoFocus={autoFocus}
-        />
-      )}
+      <input
+        name={name}
+        placeholder={placeholder}
+        className='w-full h-full px-2 text-black-font focus:outline-none'
+        type={type}
+        defaultValue={defaultValue}
+        autoFocus={autoFocus}
+      />
     </div>
   );
 }

--- a/hps/components/organisms/BottomTab/BottomTabBar.tsx
+++ b/hps/components/organisms/BottomTab/BottomTabBar.tsx
@@ -16,7 +16,7 @@ export default function BottomTabBar() {
   const router = useRouter();
 
   return (
-    <div className='fixed bottom-0 flex flex-row w-full items-center justify-center'>
+    <div className='fixed bottom-0 flex w-full items-center justify-center'>
       {tabItems.map((item) => (
         <TabBarItem
           key={item.href}

--- a/hps/lib/actions/signup.ts
+++ b/hps/lib/actions/signup.ts
@@ -9,6 +9,7 @@ type Input = {
   id: string;
   password: string;
   birth: string;
+  businessCode: string;
 };
 
 export async function handleSignUp(input: Input) {
@@ -23,7 +24,7 @@ export async function handleSignUp(input: Input) {
     };
   }
 
-  const { name, id, birth, password } = result.data;
+  const { name, id, birth, password, businessCode } = result.data;
   const birthInt = birth.replace(/-/g, ''); // YYYYMMDD 형식으로 변환
 
   const hashed = await hash(password, 10);
@@ -34,6 +35,7 @@ export async function handleSignUp(input: Input) {
       loginId: id,
       birthDate: birthInt,
       password: hashed,
+      businessCode,
     },
   });
 

--- a/hps/lib/validator.ts
+++ b/hps/lib/validator.ts
@@ -40,6 +40,7 @@ export const signUpValidator = z
     id: z.string().min(1, '아이디를 입력해주세요.'),
     password: z.string().min(6, '비밀번호는 6자 이상이어야 합니다.'),
     birth: z.string().min(1, '생년월일을 입력해주세요.'),
+    businessCode: z.string().min(1, '업종을 선택해주세요'),
   })
   .superRefine(async ({ id }, ctx) => {
     const user = await getUser(id);


### PR DESCRIPTION
<!-- PR 제목은 '[Feat] 작업 내용' 과 같은 형태로 작성해주세요.  -->

### ☝️ 이슈 번호

<!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #98 

<br>

### 📝 작업 내용

- 회원가입 페이지
  - 업종코드(businessCode) 항목을 SelectBusiness 컴포넌트로 분리하여 UI 개선 및 재사용성 향상
  - handleSignUp에 businessCode 전달 로직 연결

- 로그인 페이지
  - UI 통일성을 위해 Input, Button 스타일 정비
  - 버튼 위치, 간격, 텍스트 크기 통일

- 마이페이지
  - 비밀번호 항목을 `ChangePassword` 컴포넌트로 분리
  - 비밀번호 수정 시, 기존/새 비밀번호 입력 필드 + 취소/변경 버튼 표시
  - `******`로 기본 노출 및 아이콘 클릭 시 편집 전환
  - `ProfileItem`, `BusinessCode` 구조 일관성 유지
  - `SelectBusinessEdit` 크기 및 UI 통일 (Input 높이 맞춤, padding 조정)

<br>

### 💬 코멘트

<!-- 리뷰어가 중점적으로 봐주었으면 하는 부분이나 궁금한 점을 자유롭게 남겨주세요! -->

<br>

### 📸 구현 결과

`/signup`, `/login`, `/mypage` 에서 확인해주세요

<!-- ⚠️ 잠깐 !!!! -->
<!-- PR 제목 컨벤션에 맞게 잘 작성했는지, assignee 및 reviewer 지정했는지 다시 한 번 체크하기 !! -->
