### PR TITLE
[Feat] MainPage - 카드 든 별돌이 다음 달 예측 수입 기준으로  지출 반영해서 카드색 로직 변경

### DIFF
--- a/hps/app/components/HanaMonWithCard.tsx
+++ b/hps/app/components/HanaMonWithCard.tsx
@@ -4,22 +4,24 @@ import { consumptionData } from '@/constants/consumptionData';
 import Image from 'next/image';
 import { getConsumptionRateText } from '../consumption/utils/evaluation';
 
-type Salary = {
-  id: number;
-  userId: number;
-  amount: number;
-  depositDate: Date;
-  depositorName: string | null;
-  incomeSource: string | null;
-};
+// type Salary = {
+//   id: number;
+//   userId: number;
+//   amount: number;
+//   depositDate: Date;
+//   depositorName: string | null;
+//   incomeSource: string | null;
+// };
 
 type Props = {
-  salaryList: Salary[];
+  predictedNextMonthSalary: number;
 };
 
-export default function HanaMonWithCard({ salaryList }: Props) {
-  const predictedSalary = salaryList.reduce((sum, s) => sum + s.amount, 0);
-  const { rate } = getConsumptionRateText(predictedSalary, consumptionData);
+export default function HanaMonWithCard({ predictedNextMonthSalary }: Props) {
+  const { rate } = getConsumptionRateText(
+    predictedNextMonthSalary,
+    consumptionData
+  );
   const color =
     rate !== null
       ? rate < 60

--- a/hps/app/components/SalaryBox.tsx
+++ b/hps/app/components/SalaryBox.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation';
+import { getPredictedNextMonthSalary } from '@/lib/actions/salary-actions';
 import { auth } from '@/lib/auth';
-import { getLastIncome, getSumOfThisMonthSalaries } from '../utils/salary';
+import { getSumOfThisMonthSalaries } from '../utils/salary';
 import HanaMonWithCard from './HanaMonWithCard';
 import SalarySpendButton from './SalarySpendButton';
 
@@ -12,15 +13,15 @@ export default async function SalaryBox() {
     redirect('/login');
   }
 
-  const [sumOfSalaries, salaryList] = await Promise.all([
+  const [sumOfSalaries, predictedNextMonthSalary] = await Promise.all([
     getSumOfThisMonthSalaries(userId),
-    getLastIncome(userId),
+    getPredictedNextMonthSalary(userId),
   ]);
 
   return (
     <div className='flex mt-16 gap-4'>
       <SalarySpendButton lastSalary={sumOfSalaries} />
-      <HanaMonWithCard salaryList={salaryList} />
+      <HanaMonWithCard predictedNextMonthSalary={predictedNextMonthSalary} />
     </div>
   );
 }


### PR DESCRIPTION
<!-- PR 제목은 '[Feat] 작업 내용' 과 같은 형태로 작성해주세요.  -->

### ☝️ 이슈 번호

<!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #149 

<br>

### 📝 작업 내용

<!-- 작업 내용을 간략히 설명해주세요 -->
- 메인 페이지에 있는 카드 든 별돌이 로직을 다음과 같이 변경하였습니다.
    - 기존 
        - 이번 달 소비 < **지난 달 수입**의 30% : 레드 카드
        - **지난 달 수입**의 30% <= 이번 달 소비 < **지난 달 수입**의 30% : 옐로우 카드
        - **지난 달 수입**의 30% <= 이번 달 소비  : 그린 카드
    - 변경
        - 이번 달 소비 < **다음 달 예측 수입**의 30% : 레드 카드
        - **다음 달 예측 수입**의 30% <= 이번 달 소비 < **다음 달 예측 수입**의 30% : 옐로우 카드
        - **다음 달 예측 수입**의 30% <= 이번 달 소비  : 그린 카드


<br>

### 💬 코멘트

<!-- 리뷰어가 중점적으로 봐주었으면 하는 부분이나 궁금한 점을 자유롭게 남겨주세요! -->
- 구현 결과에 그린카드가 없는 이유는 다음 달 예측 수입으로  디비 반영이 아직 되지 않았기 때문입니다.

<br>

### 📸 구현 결과

<!-- 구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요 (스크린샷, gif, 동영상, 배포링크 등) -->
<img width="338" alt="스크린샷 2025-06-29 오후 7 43 02" src="https://github.com/user-attachments/assets/476c712b-91b4-4f16-ab66-f2fa54dd4024" />
<img width="338" alt="스크린샷 2025-06-29 오후 7 43 20" src="https://github.com/user-attachments/assets/fd3af0e8-a246-43cf-b09d-74cb09fc13e1" />
<img width="338" alt="스크린샷 2025-06-29 오후 7 43 33" src="https://github.com/user-attachments/assets/9a3b7145-fbdf-4493-856f-f5e3108c79e3" />


<!-- ⚠️ 잠깐 !!!! -->
<!-- PR 제목 컨벤션에 맞게 잘 작성했는지, assignee 및 reviewer 지정했는지 다시 한 번 체크하기 !! -->
